### PR TITLE
Using pImpl to avoid the usage of void*

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.a
 /example
 /.vscode/
+build
+.cache

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 STATIC_LIB = liblokal.a
 SHARED_LIB = liblokal.so
-SOURCES = src/LokalSo/Lokal.cpp
+SOURCES = src/LokalSo/Lokal.cpp src/LokalSo/CurlWrapper.cpp
 HEADERS = $(SOURCES:.cpp=.hpp)
 OBJECTS = $(SOURCES:.cpp=.o)
 INCLUDE = -I./src/

--- a/src/LokalSo/CurlWrapper.cpp
+++ b/src/LokalSo/CurlWrapper.cpp
@@ -1,0 +1,175 @@
+#include <stdexcept>
+#include <algorithm>
+
+#include "CurlWrapper.hpp"
+
+namespace LokalSo {
+    
+    static void ltrim(std::string &s) {
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+            return !std::isspace(ch);
+        }));
+    }
+
+    static void rtrim(std::string &s) {
+        s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+            return !std::isspace(ch);
+        }).base(), s.end());
+    }
+    
+    static void trim(std::string &s) {
+        rtrim(s);
+        ltrim(s);
+    }
+
+    void Header::addHeader(std::string const& key, std::string const& value) {
+        this->headerMap.emplace(std::make_pair(key, value));
+    }
+    std::string Header::getValue(std::string const& key) const {
+        auto it = this->headerMap.find(key);
+        if (it == this->headerMap.end())
+            return "";
+        return it->second;
+    }
+    std::unordered_map<std::string, std::string> const& Header::getHeader() const {
+        return this->headerMap;
+    }
+
+    static size_t res_body_callback(void *contents, size_t size, size_t nmemb, void *userp) {
+        CurlWrapper* mem = static_cast<CurlWrapper*>(userp);
+        size_t full_size = size * nmemb;
+
+        mem->appendResponseBody(std::string{static_cast<char *>(contents),full_size});
+        return full_size;
+    }
+
+    static size_t res_hdr_callback(void *contents, size_t size, size_t nmemb,
+			       void *userp) {
+        CurlWrapper* mem = static_cast<CurlWrapper*>(userp);
+        size_t full_size = size * nmemb;
+
+        std::string headerStr(static_cast<char *>(contents), full_size);
+
+        auto colon = headerStr.find(':');
+        if (colon != std::string::npos) {
+            std::string key = headerStr.substr(0, colon);
+            std::string value = headerStr.substr(colon + 1);
+            // Trim whitespace from key and value
+            trim(key);
+            trim(value);
+            mem->addResponseHeader(key, value);
+        }
+        return full_size;
+    }
+
+
+    CurlWrapper::CurlWrapper() {
+        this->ch = curl_easy_init();
+        curl_easy_setopt(this->ch, CURLOPT_WRITEFUNCTION, &res_body_callback);
+	    curl_easy_setopt(this->ch, CURLOPT_WRITEDATA, this);
+
+        curl_easy_setopt(this->ch, CURLOPT_HEADERFUNCTION, &res_hdr_callback);
+	    curl_easy_setopt(this->ch, CURLOPT_HEADERDATA, this);
+
+    }
+    CurlWrapper::~CurlWrapper() {
+        if(this->ch) {
+            curl_easy_cleanup(this->ch);
+        }
+        if(this->sList) {
+            curl_slist_free_all(this->sList);
+        }
+    }
+
+    
+    void CurlWrapper::appendResponseBody(std::string const& responseBody) {
+        this->responseBody.append(responseBody);
+    }
+    void CurlWrapper::addResponseHeader(std::string const& key, std::string const& value) {
+        this->responseHeader.addHeader(key, value);
+    }
+
+    void CurlWrapper::setURL(std::string const& url) {
+        this->url = url;
+    }
+
+    void CurlWrapper::addHeader(std::string const& key, std::string const& value) {
+        this->requestHeader.addHeader(key, value);
+    }
+    void CurlWrapper::setMethod(std::string const& method) {
+        this->method = method;
+    }
+
+    void CurlWrapper::setReqBody(std::string const& requestBody) {
+        this->requestBody = requestBody;
+        
+    }
+    void CurlWrapper::setUserAgent(std::string const& userAgent) {
+        this->userAgent = userAgent;
+    }
+
+    void CurlWrapper::execute() {
+	    curl_easy_setopt(this->ch, CURLOPT_URL, this->url.c_str());
+	    curl_easy_setopt(this->ch, CURLOPT_USERAGENT, this->userAgent.c_str());
+    	curl_easy_setopt(this->ch, CURLOPT_CUSTOMREQUEST, this->method.c_str());
+
+
+        curl_easy_setopt(this->ch, CURLOPT_POST, 1L);
+		curl_easy_setopt(this->ch, CURLOPT_POSTFIELDS, this->requestBody.data());
+		curl_easy_setopt(this->ch, CURLOPT_POSTFIELDSIZE, this->requestBody.size());
+
+        for (auto const& headerMap:this->requestHeader.getHeader()) {
+            // Content-Type: application/json
+
+            std::string sep{": "};
+            std::string headerVal{headerMap.first + sep + headerMap.second};
+            this->sList =  curl_slist_append(this->sList, headerVal.c_str());
+        }
+
+        auto res = curl_easy_perform(ch);
+        if (res != CURLE_OK) {
+            this->reset();
+            throw std::runtime_error(curl_easy_strerror(res));
+	    }
+        this->reset();
+    }
+
+    
+    Header const& CurlWrapper::getReqHeader() const {
+        return this->requestHeader;
+    }
+    std::string const& CurlWrapper::getReqBody() const {
+        return this->requestBody;
+    }
+
+    Header const& CurlWrapper::getResHeader() const {
+        return this->responseHeader;
+    }
+
+    std::string const& CurlWrapper::getResBody() const {
+        return this->responseBody;
+    }
+
+    void CurlWrapper::reset() {
+        this->method = "GET";
+        this->requestBody.clear();
+        this->requestHeader = {};
+        this->url.clear();
+        // keep user agent inside the class
+
+
+        if(this->sList) {
+            curl_slist_free_all(this->sList);
+            this->sList = nullptr;
+        }
+        
+        
+        curl_easy_reset(this->ch);
+	    // curl_easy_setopt(this->ch, CURLOPT_URL, nullptr);
+        // curl_easy_setopt(this->ch, CURLOPT_POST, 0L);
+		// curl_easy_setopt(this->ch, CURLOPT_POSTFIELDSIZE, 0);
+		// curl_easy_setopt(this->ch, CURLOPT_POSTFIELDS, nullptr);
+    	// curl_easy_setopt(ch, CURLOPT_HTTPHEADER, nullptr);
+    }
+
+}

--- a/src/LokalSo/CurlWrapper.cpp
+++ b/src/LokalSo/CurlWrapper.cpp
@@ -32,6 +32,12 @@ static void trim(std::string &s)
         ltrim(s);
 }
 
+static void toLower(std::string &s)
+{
+        std::transform(s.begin(), s.end(), s.begin(),
+        [](unsigned char c){ return std::tolower(c); });
+}
+
 void Header::addHeader(std::string const& key, std::string const& value)
 {
         this->headerMap.emplace(std::make_pair(key, value));
@@ -70,6 +76,7 @@ static size_t res_hdr_callback(void *contents, size_t size, size_t nmemb, void *
                 std::string value = headerStr.substr(colon + 1);
 
                 trim(key);
+                toLower(key);
                 trim(value);
                 mem->addResponseHeader(key, value);
         }

--- a/src/LokalSo/CurlWrapper.cpp
+++ b/src/LokalSo/CurlWrapper.cpp
@@ -7,52 +7,58 @@
 #include "json.hpp"
 
 namespace LokalSo {
+using json = nlohmann::json;
 
-    using json = nlohmann::json;
+// https://www.boost.org/doc/libs/1_59_0/libs/smart_ptr/sp_techniques.html#handle
+using defer = std::shared_ptr<void>;
 
-    // https://www.boost.org/doc/libs/1_59_0/libs/smart_ptr/sp_techniques.html#handle
-    using defer = std::shared_ptr<void>;  
-    
-    static void ltrim(std::string &s) {
+static void ltrim(std::string &s)
+{
         s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
-            return !std::isspace(ch);
+        return !std::isspace(ch);
         }));
-    }
+}
 
-    static void rtrim(std::string &s) {
+static void rtrim(std::string &s)
+{
         s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
-            return !std::isspace(ch);
+        return !std::isspace(ch);
         }).base(), s.end());
-    }
+}
 
-    static void trim(std::string &s) {
+static void trim(std::string &s)
+{
         rtrim(s);
         ltrim(s);
-    }
+}
 
-    void Header::addHeader(std::string const& key, std::string const& value) {
+void Header::addHeader(std::string const& key, std::string const& value)
+{
         this->headerMap.emplace(std::make_pair(key, value));
-    }
-    std::string Header::getValue(std::string const& key) const {
+}
+std::string Header::getValue(std::string const& key) const
+{
         auto it = this->headerMap.find(key);
         if (it == this->headerMap.end())
-            return "";
+                return "";
         return it->second;
-    }
-    std::unordered_map<std::string, std::string> const& Header::getHeader() const {
+}
+std::unordered_map<std::string, std::string> const& Header::getHeader() const
+{
         return this->headerMap;
-    }
+}
 
-    static size_t res_body_callback(void *contents, size_t size, size_t nmemb, void *userp) {
+static size_t res_body_callback(void *contents, size_t size, size_t nmemb, void *userp)
+{
         CurlWrapper* mem = static_cast<CurlWrapper*>(userp);
         size_t full_size = size * nmemb;
 
         mem->appendResponseBody(std::string{static_cast<char *>(contents),full_size});
         return full_size;
-    }
+}
 
-    static size_t res_hdr_callback(void *contents, size_t size, size_t nmemb,
-			       void *userp) {
+static size_t res_hdr_callback(void *contents, size_t size, size_t nmemb, void *userp)
+{
         CurlWrapper* mem = static_cast<CurlWrapper*>(userp);
         size_t full_size = size * nmemb;
 
@@ -60,139 +66,144 @@ namespace LokalSo {
 
         auto colon = headerStr.find(':');
         if (colon != std::string::npos) {
-            std::string key = headerStr.substr(0, colon);
-            std::string value = headerStr.substr(colon + 1);
-            // Trim whitespace from key and value
-            trim(key);
-            trim(value);
-            mem->addResponseHeader(key, value);
+                std::string key = headerStr.substr(0, colon);
+                std::string value = headerStr.substr(colon + 1);
+
+                trim(key);
+                trim(value);
+                mem->addResponseHeader(key, value);
         }
         return full_size;
-    }
+}
 
 
-    CurlWrapper::CurlWrapper() {
+CurlWrapper::CurlWrapper()
+{
         this->ch = curl_easy_init();
+
         curl_easy_setopt(this->ch, CURLOPT_WRITEFUNCTION, &res_body_callback);
-	    curl_easy_setopt(this->ch, CURLOPT_WRITEDATA, this);
+        curl_easy_setopt(this->ch, CURLOPT_WRITEDATA, this);
 
         curl_easy_setopt(this->ch, CURLOPT_HEADERFUNCTION, &res_hdr_callback);
-	    curl_easy_setopt(this->ch, CURLOPT_HEADERDATA, this);
+        curl_easy_setopt(this->ch, CURLOPT_HEADERDATA, this);
 
-    }
-    CurlWrapper::~CurlWrapper() {
-        if(this->ch) {
-            curl_easy_cleanup(this->ch);
-        }
-        if(this->sList) {
-            curl_slist_free_all(this->sList);
-        }
-    }
+}
+CurlWrapper::~CurlWrapper()
+{
+        if (this->ch != nullptr)
+                curl_easy_cleanup(this->ch);
 
-    
-    void CurlWrapper::appendResponseBody(std::string const& responseBody) {
+        if (this->sList != nullptr)
+                curl_slist_free_all(this->sList);
+}
+
+void CurlWrapper::appendResponseBody(std::string const& responseBody)
+{
         this->responseBody.append(responseBody);
-    }
-    void CurlWrapper::addResponseHeader(std::string const& key, std::string const& value) {
+}
+void CurlWrapper::addResponseHeader(std::string const& key, std::string const& value)
+{
         this->responseHeader.addHeader(key, value);
-    }
+}
 
-    void CurlWrapper::setURL(std::string const& url) {
+void CurlWrapper::setURL(std::string const& url)
+{
         this->url = url;
-    }
+}
 
-    void CurlWrapper::addHeader(std::string const& key, std::string const& value) {
+void CurlWrapper::addHeader(std::string const& key, std::string const& value)
+{
         this->requestHeader.addHeader(key, value);
-    }
-    void CurlWrapper::setMethod(std::string const& method) {
+}
+void CurlWrapper::setMethod(std::string const& method)
+{
         this->method = method;
-    }
+}
 
-    void CurlWrapper::setReqBody(std::string const& requestBody) {
+void CurlWrapper::setReqBody(std::string const& requestBody)
+{
         this->requestBody = requestBody;
-        
-    }
-    void CurlWrapper::setUserAgent(std::string const& userAgent) {
+}
+void CurlWrapper::setUserAgent(std::string const& userAgent)
+{
         this->userAgent = userAgent;
-    }
-
-    void CurlWrapper::execute() {
-	    curl_easy_setopt(this->ch, CURLOPT_URL, this->url.c_str());
-	    curl_easy_setopt(this->ch, CURLOPT_USERAGENT, this->userAgent.c_str());
-    	curl_easy_setopt(this->ch, CURLOPT_CUSTOMREQUEST, this->method.c_str());
+}
 
 
+void CurlWrapper::execute()
+{
+        curl_easy_setopt(this->ch, CURLOPT_URL, this->url.c_str());
+        curl_easy_setopt(this->ch, CURLOPT_USERAGENT, this->userAgent.c_str());
+        curl_easy_setopt(this->ch, CURLOPT_CUSTOMREQUEST, this->method.c_str());
         curl_easy_setopt(this->ch, CURLOPT_POST, 1L);
-		curl_easy_setopt(this->ch, CURLOPT_POSTFIELDS, this->requestBody.data());
-		curl_easy_setopt(this->ch, CURLOPT_POSTFIELDSIZE, this->requestBody.size());
+        curl_easy_setopt(this->ch, CURLOPT_POSTFIELDS, this->requestBody.data());
+        curl_easy_setopt(this->ch, CURLOPT_POSTFIELDSIZE, this->requestBody.size());
 
         for (auto const& headerMap:this->requestHeader.getHeader()) {
-            // Content-Type: application/json
+                // Content-Type: application/json
 
-            std::string sep{": "};
-            std::string headerVal{headerMap.first + sep + headerMap.second};
-            this->sList =  curl_slist_append(this->sList, headerVal.c_str());
+                std::string sep{": "};
+                std::string headerVal{headerMap.first + sep + headerMap.second};
+                this->sList =  curl_slist_append(this->sList, headerVal.c_str());
         }
-        
+
         defer _(nullptr, std::bind([&]{ this->reset(); }));
         auto res = curl_easy_perform(ch);
         if (res != CURLE_OK) {
-            throw std::runtime_error(curl_easy_strerror(res));
-	    }
+                throw std::runtime_error(curl_easy_strerror(res));
+        }
 
         long http_code {0};
-        
+
         curl_easy_getinfo(ch, CURLINFO_RESPONSE_CODE, &http_code);
         if (http_code != 200) {
-            std::string msg;
+                std::string msg;
 
-            try {
-                json j = json::parse(this->responseBody);
-                msg = j["message"];
-            } catch (json::parse_error const& e) {
-                msg = "";
-            }
+                try {
+                        json j = json::parse(this->responseBody);
+                        msg = j["message"];
+                } catch (json::parse_error const& e) {
+                        msg = "";
+                }
 
-            throw std::runtime_error("HTTP error: " + std::to_string(http_code) + ": " + msg);
+                throw std::runtime_error("HTTP error: " + std::to_string(http_code) + ": " + msg);
         }
-    }
+}
 
-    
-    Header const& CurlWrapper::getReqHeader() const {
+
+Header const& CurlWrapper::getReqHeader() const
+{
         return this->requestHeader;
-    }
-    std::string const& CurlWrapper::getReqBody() const {
+}
+std::string const& CurlWrapper::getReqBody() const
+{
         return this->requestBody;
-    }
+}
 
-    Header const& CurlWrapper::getResHeader() const {
+Header const& CurlWrapper::getResHeader() const
+{
         return this->responseHeader;
-    }
+}
 
-    std::string const& CurlWrapper::getResBody() const {
+std::string const& CurlWrapper::getResBody() const
+{
         return this->responseBody;
-    }
+}
 
-    void CurlWrapper::reset() {
+void CurlWrapper::reset()
+{
         this->method = "GET";
         this->requestBody.clear();
         this->requestHeader = {};
         this->url.clear();
         // keep user agent inside the class
 
-
-        if(this->sList) {
-            curl_slist_free_all(this->sList);
-            this->sList = nullptr;
+        if (this->sList != nullptr) {
+                curl_slist_free_all(this->sList);
+                this->sList = nullptr;
         }
-        
-        
-        curl_easy_reset(this->ch);
-	    // curl_easy_setopt(this->ch, CURLOPT_URL, nullptr);
-        // curl_easy_setopt(this->ch, CURLOPT_POST, 0L);
-		// curl_easy_setopt(this->ch, CURLOPT_POSTFIELDSIZE, 0);
-		// curl_easy_setopt(this->ch, CURLOPT_POSTFIELDS, nullptr);
-    	// curl_easy_setopt(ch, CURLOPT_HTTPHEADER, nullptr);
-    }
 
+        curl_easy_reset(this->ch);
 }
+
+} // namespace LokalSo

--- a/src/LokalSo/CurlWrapper.hpp
+++ b/src/LokalSo/CurlWrapper.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#ifndef LOKALSO__CURL_WRAPPER_HPP
+#define LOKALSO__CURL_WRAPPER_HPP
+
+#include <curl/curl.h>
+
+#include <string>
+#include <unordered_map>
+
+namespace LokalSo {
+
+    class Header {
+    private:
+        std::unordered_map<std::string, std::string> headerMap;
+    public:
+        Header() = default;
+        Header(std::unordered_map<std::string, std::string> const& headerMap): headerMap(headerMap) {}
+        
+        void addHeader(std::string const& key, std::string const& value);
+        std::string getValue(std::string const& key) const;
+        std::unordered_map<std::string, std::string> const& getHeader() const;
+    };
+
+    class CurlWrapper {
+    private:
+        CURL *ch;
+        curl_slist *sList {nullptr};
+
+        std::string url;
+        std::string method{"GET"};
+        std::string userAgent;
+        std::string requestBody;
+        Header requestHeader;
+
+        std::string responseBody;
+        Header responseHeader;
+
+        void reset();
+
+    public:
+        CurlWrapper();
+        ~CurlWrapper();
+        void appendResponseBody(std::string const& body);
+        void addResponseHeader(std::string const& key, std::string const& value);
+        
+        void setURL(std::string const& url);
+        void addHeader(std::string const& key, std::string const& value);
+        void setMethod(std::string const& method);
+        void setReqBody(std::string const& body);
+        void setUserAgent(std::string const& userAgent);
+        void execute();
+        Header const& getResHeader() const;
+        std::string const& getResBody() const;
+        
+        Header const& getReqHeader() const;
+        std::string const& getReqBody() const;
+
+    };
+
+}
+#endif

--- a/src/LokalSo/CurlWrapper.hpp
+++ b/src/LokalSo/CurlWrapper.hpp
@@ -9,21 +9,22 @@
 #include <unordered_map>
 
 namespace LokalSo {
-
-    class Header {
-    private:
+class Header
+{
+private:
         std::unordered_map<std::string, std::string> headerMap;
-    public:
+public:
         Header() = default;
         Header(std::unordered_map<std::string, std::string> const& headerMap): headerMap(headerMap) {}
-        
+
         void addHeader(std::string const& key, std::string const& value);
         std::string getValue(std::string const& key) const;
         std::unordered_map<std::string, std::string> const& getHeader() const;
-    };
+};
 
-    class CurlWrapper {
-    private:
+class CurlWrapper
+{
+private:
         CURL *ch;
         curl_slist *sList {nullptr};
 
@@ -38,12 +39,12 @@ namespace LokalSo {
 
         void reset();
 
-    public:
+public:
         CurlWrapper();
         ~CurlWrapper();
         void appendResponseBody(std::string const& body);
         void addResponseHeader(std::string const& key, std::string const& value);
-        
+
         void setURL(std::string const& url);
         void addHeader(std::string const& key, std::string const& value);
         void setMethod(std::string const& method);
@@ -52,11 +53,10 @@ namespace LokalSo {
         void execute();
         Header const& getResHeader() const;
         std::string const& getResBody() const;
-        
+
         Header const& getReqHeader() const;
         std::string const& getReqBody() const;
+};
 
-    };
-
-}
+} // namespace LokalSo
 #endif

--- a/src/LokalSo/Lokal.cpp
+++ b/src/LokalSo/Lokal.cpp
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-only
 
 #include "Lokal.hpp"
+#include "CurlWrapper.hpp"
 
 #include <curl/curl.h>
 #include <stdexcept>
@@ -71,108 +72,63 @@ void Tunnel::__showStartupBanner(void)
 LOKAL_CONST_DEF_CPP(Lokal::TunnelTypeHTTP);
 
 Lokal::Lokal(std::string base_url):
-	curl_(nullptr),
 	base_url_(base_url)
 {
+	this->curl_pImpl = std::make_unique<CurlImpl>();
 }
 
 Lokal::~Lokal(void)
 {
-	if (curl_)
-		curl_easy_cleanup(static_cast<CURL *>(curl_));
 }
 
-struct curl_data {
-	std::string res_body;
-	std::string res_hdr;
-	bool version_ok;
+class Lokal::CurlImpl {
+private:
+	CurlWrapper curlWrapper;
+public:
+	CurlImpl() {}
+	void setURL(std::string const& url) {
+		return this->curlWrapper.setURL(url);
+	}
+	void addHeader(std::string const& key, std::string const& value) {
+		return this->curlWrapper.addHeader(key, value);
+	}
+	void setMethod(std::string const& method) {
+		return this->curlWrapper.setMethod(method);
+	}
+	void setReqBody(std::string const& body) {
+		return this->curlWrapper.setReqBody(body);
+	}
+	void setUserAgent(std::string const& userAgent) {
+		return this->curlWrapper.setUserAgent(userAgent);
+	}
+	void execute() {
+		return this->execute();
+	}
+	Header const& getResHeader() const {
+		return this->curlWrapper.getResHeader();
+
+	}
+	std::string const& getResBody() const {
+		return this->curlWrapper.getResBody();
+	}
 };
-
-static size_t res_body_callback(void *contents, size_t size, size_t nmemb,
-				void *userp)
-{
-	struct curl_data *mem = (struct curl_data *)userp;
-	size_t full_size = size * nmemb;
-
-	mem->res_body.append((char *)contents, full_size);
-	return full_size;
-}
-
-static size_t res_hdr_callback(void *contents, size_t size, size_t nmemb,
-			       void *userp)
-{
-	struct curl_data *mem = (struct curl_data *)userp;
-	size_t full_size = size * nmemb;
-
-	mem->res_hdr.append((char *)contents, full_size);
-	return full_size;
-}
 
 std::string Lokal::post(std::string path, std::string data)
 {
-	return __curl(path, "POST", data);
+	std::string url {this->base_url_ + path};
+	this->curl_pImpl->setURL(url);
+	this->curl_pImpl->setMethod("POST");
+	this->curl_pImpl->setUserAgent("Lokal Cpp - github.com/lokal-so/lokal-cpp");
+	this->curl_pImpl->addHeader("Content-Type", "application/json");
+	this->curl_pImpl->setReqBody(data);
+	this->curl_pImpl->execute();
+
+	// TODO: check server version
+	std::string serverVersion = this->curl_pImpl->getResHeader().getValue("Lokal-Server-Version");
+	// TODO: implement SemVer and lessThan method
+
+	return this->curl_pImpl->getResBody();
 }
 
-std::string Lokal::__curl(std::string path, std::string method,
-			  std::string req_body)
-{
-	struct curl_slist *headers = nullptr;
-	std::string url = base_url_ + path;
-	struct curl_data data;
-	long http_code = 0;
-	CURLcode res;
-	CURL *ch;
-
-	if (!curl_) {
-		ch = curl_easy_init();
-		if (!ch)
-			throw std::runtime_error("Failed to initialize curl");
-
-		curl_ = static_cast<void *>(ch);
-	} else {
-		ch = static_cast<CURL *>(curl_);
-	}
-
-	headers = curl_slist_append(headers, "Content-Type: application/json");
-
-	curl_easy_setopt(ch, CURLOPT_URL, url.c_str());
-	curl_easy_setopt(ch, CURLOPT_CUSTOMREQUEST, method.c_str());
-	curl_easy_setopt(ch, CURLOPT_WRITEFUNCTION, &res_body_callback);
-	curl_easy_setopt(ch, CURLOPT_WRITEDATA, &data);
-	curl_easy_setopt(ch, CURLOPT_HEADERFUNCTION, &res_hdr_callback);
-	curl_easy_setopt(ch, CURLOPT_HEADERDATA, &data);
-	curl_easy_setopt(ch, CURLOPT_USERAGENT, "Lokal Go - github.com/lokal-so/lokal-go");
-	curl_easy_setopt(ch, CURLOPT_VERBOSE, 0L);
-	curl_easy_setopt(ch, CURLOPT_HTTPHEADER, headers);
-	if (req_body != "") {
-		curl_easy_setopt(ch, CURLOPT_POST, 1L);
-		curl_easy_setopt(ch, CURLOPT_POSTFIELDSIZE, req_body.size());
-		curl_easy_setopt(ch, CURLOPT_POSTFIELDS, req_body.c_str());
-	}
-
-	res = curl_easy_perform(ch);
-	curl_slist_free_all(headers);
-	if (res != CURLE_OK) {
-		curl_ = nullptr;
-		curl_easy_cleanup(ch);
-		throw std::runtime_error(curl_easy_strerror(res));
-	}
-
-	curl_easy_getinfo(ch, CURLINFO_RESPONSE_CODE, &http_code);
-	if (http_code != 200) {
-		std::string msg;
-
-		try {
-			json j = json::parse(data.res_body);
-			msg = j["message"];
-		} catch (json::parse_error &e) {
-			msg = "";
-		}
-
-		throw std::runtime_error("HTTP error: " + std::to_string(http_code) + ": " + msg);
-	}
-
-	return data.res_body;
-}
 
 } /* namespace LokalSo */

--- a/src/LokalSo/Lokal.cpp
+++ b/src/LokalSo/Lokal.cpp
@@ -102,7 +102,7 @@ public:
 		return this->curlWrapper.setUserAgent(userAgent);
 	}
 	void execute() {
-		return this->execute();
+		return this->curlWrapper.execute();
 	}
 	Header const& getResHeader() const {
 		return this->curlWrapper.getResHeader();

--- a/src/LokalSo/Lokal.hpp
+++ b/src/LokalSo/Lokal.hpp
@@ -216,13 +216,11 @@ public:
 	}
 
 	std::string post(std::string path, std::string data);
+	class CurlImpl;
+
 
 private:
-
-	std::string __curl(std::string path, std::string method,
-			   std::string req_body = "");
-
-	void *curl_;
+	std::unique_ptr<CurlImpl> curl_pImpl;
 	std::string base_url_;
 	std::vector<std::unique_ptr<Tunnel>> tunnels_;
 };

--- a/test/CurlWrapper.cpp
+++ b/test/CurlWrapper.cpp
@@ -1,0 +1,44 @@
+// Let the test here for now. I will integrate this test on another PR
+
+#include <gtest/gtest.h>
+
+#include <CurlWrapper.hpp>
+
+using namespace LokalSo;
+
+TEST(CurlWrapper, CreateCurlWrapper) {
+    CurlWrapper curl{};
+}
+
+
+TEST(CurlWrapper, CreateWithProperties) {
+    CurlWrapper curl{};
+    curl.addHeader("Content-Type", "application/json");
+    curl.addHeader("Signature", "JustASignature");
+    
+    // By default GET
+    // curl.setMethod("GET")
+
+    curl.setUserAgent("UserAgent");
+    curl.setURL("https://google.com");
+
+    ASSERT_EQ(curl.getReqHeader().getValue("Content-Type") , "application/json");
+    ASSERT_EQ(curl.getReqHeader().getValue("Signature") , "JustASignature");
+
+
+    ASSERT_NO_THROW(curl.execute());
+
+    ASSERT_TRUE(curl.getReqHeader().getHeader().empty());
+    ASSERT_TRUE(!curl.getResBody().empty());
+    ASSERT_TRUE(!curl.getResHeader().getHeader().empty());
+    
+
+}
+
+TEST(CurlWrapper, FailToExecute) {
+    CurlWrapper curl{};
+
+    curl.setURL("https://127.0.0.1:8080");
+
+    ASSERT_THROW(curl.execute(), std::runtime_error);
+}

--- a/test/CurlWrapper.cpp
+++ b/test/CurlWrapper.cpp
@@ -20,7 +20,7 @@ TEST(CurlWrapper, CreateWithProperties) {
     // curl.setMethod("GET")
 
     curl.setUserAgent("UserAgent");
-    curl.setURL("https://google.com");
+    curl.setURL("https://github.com");
 
     ASSERT_EQ(curl.getReqHeader().getValue("Content-Type") , "application/json");
     ASSERT_EQ(curl.getReqHeader().getValue("Signature") , "JustASignature");
@@ -37,8 +37,18 @@ TEST(CurlWrapper, CreateWithProperties) {
 
 TEST(CurlWrapper, FailToExecute) {
     CurlWrapper curl{};
+    curl.addHeader("Content-Type", "application/json");
+    curl.addHeader("Signature", "JustASignature");
+    
+    // By default GET
+    // curl.setMethod("GET")
+
+    curl.setUserAgent("UserAgent");
+    curl.setURL("https://google.com");
 
     curl.setURL("https://127.0.0.1:8080");
 
     ASSERT_THROW(curl.execute(), std::runtime_error);
+
+    ASSERT_TRUE(curl.getReqHeader().getHeader().empty());
 }

--- a/test/CurlWrapper.cpp
+++ b/test/CurlWrapper.cpp
@@ -12,43 +12,43 @@ TEST(CurlWrapper, CreateCurlWrapper) {
 
 
 TEST(CurlWrapper, CreateWithProperties) {
-    CurlWrapper curl{};
-    curl.addHeader("Content-Type", "application/json");
-    curl.addHeader("Signature", "JustASignature");
-    
-    // By default GET
-    // curl.setMethod("GET")
+        CurlWrapper curl{};
+        curl.addHeader("Content-Type", "application/json");
+        curl.addHeader("Signature", "JustASignature");
 
-    curl.setUserAgent("UserAgent");
-    curl.setURL("https://github.com");
+        // By default GET
+        // curl.setMethod("GET")
 
-    ASSERT_EQ(curl.getReqHeader().getValue("Content-Type") , "application/json");
-    ASSERT_EQ(curl.getReqHeader().getValue("Signature") , "JustASignature");
+        curl.setUserAgent("UserAgent");
+        curl.setURL("https://github.com");
 
+        ASSERT_EQ(curl.getReqHeader().getValue("Content-Type") , "application/json");
+        ASSERT_EQ(curl.getReqHeader().getValue("Signature") , "JustASignature");
 
-    ASSERT_NO_THROW(curl.execute());
+        ASSERT_NO_THROW(curl.execute());
 
-    ASSERT_TRUE(curl.getReqHeader().getHeader().empty());
-    ASSERT_TRUE(!curl.getResBody().empty());
-    ASSERT_TRUE(!curl.getResHeader().getHeader().empty());
-    
+        // reset is called
+        ASSERT_TRUE(curl.getReqHeader().getHeader().empty());
 
+        ASSERT_FALSE(curl.getResBody().empty());
+        ASSERT_FALSE(curl.getResHeader().getHeader().empty());
 }
 
 TEST(CurlWrapper, FailToExecute) {
-    CurlWrapper curl{};
-    curl.addHeader("Content-Type", "application/json");
-    curl.addHeader("Signature", "JustASignature");
-    
-    // By default GET
-    // curl.setMethod("GET")
+        CurlWrapper curl{};
+        curl.addHeader("Content-Type", "application/json");
+        curl.addHeader("Signature", "JustASignature");
 
-    curl.setUserAgent("UserAgent");
-    curl.setURL("https://google.com");
+        // By default GET
+        // curl.setMethod("GET")
 
-    curl.setURL("https://127.0.0.1:8080");
+        curl.setUserAgent("UserAgent");
+        curl.setURL("https://127.0.0.1:8080");
 
-    ASSERT_THROW(curl.execute(), std::runtime_error);
+        ASSERT_TRUE(!curl.getReqHeader().getHeader().empty());
 
-    ASSERT_TRUE(curl.getReqHeader().getHeader().empty());
+        ASSERT_THROW(curl.execute(), std::runtime_error);
+
+        // Make sure reset is called
+        ASSERT_TRUE(curl.getReqHeader().getHeader().empty());
 }


### PR DESCRIPTION
1. Using void* to hide the real implementation is not recommended because it will stop the compiler from being able to enforce type checking
2. Add unittest using gtest

Reference
1. https://en.cppreference.com/w/cpp/language/pimpl